### PR TITLE
FixMachOLibraryPaths

### DIFF
--- a/eden-macos.sh
+++ b/eden-macos.sh
@@ -46,6 +46,23 @@ ccache -s -v
 APP=./bin/eden.app
 macdeployqt "$APP"
 macdeployqt "$APP" -always-overwrite -verbose=2
+
+# FixMachOLibraryPaths
+find "$APP/Contents/Frameworks" ""$APP/Contents/MacOS"" -type f \( -name "*.dylib" -o -perm +111 \) | while read file; do
+    if file "$file" | grep -q "Mach-O"; then
+        otool -L "$file" | awk '/@rpath\// {print $1}' | while read lib; do
+            lib_name="${lib##*/}"
+            new_path="@executable_path/../Frameworks/$lib_name"
+            install_name_tool -change "$lib" "$new_path" "$file"
+        done
+
+        if [[ "$file" == *.dylib ]]; then
+            lib_name="${file##*/}"
+            new_id="@executable_path/../Frameworks/$lib_name"
+            install_name_tool -id "$new_id" "$file"
+        fi
+    fi
+done
 codesign --deep --force --verify --verbose --sign - "$APP"
 
 # Pack for upload


### PR DESCRIPTION
I am running the arm64 version normally, but when running the x86_64 version, I encountered errors such as `@rpath/libwebp.7.dylib` and `@rpath/libsharpyuv.0.dylib` not finding `eden.app/Contents/Frameworks/../lib/libwebp.7.dylib`. The correct path should be `@executable_path/../Frameworks/`, not `eden.app/Contents/Frameworks/../lib/`, These two dylibs are both located in the Frameworks directory and exist in that folder!
```
test@testdexuniji ~ % /Users/test/Downloads/Eden-27312-MacOS-x86_64/eden.app/Contents/MacOS/eden ; exit;
dyld[21553]: Library not loaded: @rpath/libwebp.7.dylib
  Referenced from: <6A64DC7B-3963-3EC6-9D17-ECE06FF0B2D8> /Users/test/Downloads/Eden-27312-MacOS-x86_64/eden.app/Contents/Frameworks/libwebpmux.3.dylib
  Reason: tried: '/Users/test/Downloads/Eden-27312-MacOS-x86_64/eden.app/Contents/Frameworks/../lib/libwebp.7.dylib' (no such file), '/usr/local/lib/libwebp.7.dylib' (no such file), '/usr/lib/libwebp.7.dylib' (no such file, not in dyld cache)Library not loaded: @rpath/libsharpyuv.0.dylib
  Referenced from: <78804BAC-4BF8-34FD-8A5D-6FB769C14779> /Users/test/Downloads/Eden-27312-MacOS-x86_64/eden.app/Contents/Frameworks/libwebp.7.dylib
  Reason: tried: '/Users/test/Downloads/Eden-27312-MacOS-x86_64/eden.app/Contents/Frameworks/../lib/libsharpyuv.0.dylib' (no such file), '/usr/local/lib/libsharpyuv.0.dylib' (no such file), '/usr/lib/libsharpyuv.0.dylib' (no such file, not in dyld cache)
zsh: abort      /Users/test/Downloads/Eden-27312-MacOS-x86_64/eden.app/Contents/MacOS/eden
```

Fixes dynamic library paths in macOS application bundles by:
1. Changing @rpath references to use @executable_path
2. Updating dylib IDs to use proper relative paths