### PR TITLE
add back light version appimage

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -90,14 +90,18 @@ jobs:
         run: |
           chmod +x ./eden-appimage.sh
           ./eden-appimage.sh ${{ matrix.target }}
-          mkdir -p dist
-          mv *.AppImage* dist/
 
-      - name: Upload artifact
+      - name: Upload appimage with mesa
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: eden-${{ matrix.target}}-appimage
-          path: "dist"
+          name: eden-${{ matrix.target}}-mesa-appimage
+          path: mesa
+
+      - name: Upload appimage light
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: eden-${{ matrix.target}}-light-appimage
+          path: light        
           
   android: 
     runs-on: ubuntu-latest
@@ -150,9 +154,9 @@ jobs:
            - target: x86_64
              arch: x86_64
              qt_arch: win64_msvc2022_64
-           - target: x86_arm64
-             arch: ARM64
-             qt_arch: win64_msvc2022_arm64_cross_compiled
+#           - target: x86_arm64
+#             arch: ARM64
+#             qt_arch: win64_msvc2022_arm64_cross_compiled
     env:
       TARGET: ${{ matrix.target }}
       ARCH: ${{ matrix.arch }}        
@@ -253,48 +257,52 @@ jobs:
     steps:    
       - uses: actions/download-artifact@v4.3.0
         with:
-           name: eden-steamdeck-appimage
-        continue-on-error: true
- 
+           name: eden-steamdeck-mesa-appimage
+           
       - uses: actions/download-artifact@v4.3.0
         with:
-           name: eden-common-appimage
-        continue-on-error: true
-        
+           name: eden-steamdeck-light-appimage 
+           
       - uses: actions/download-artifact@v4.3.0
         with:
-           name: eden-aarch64-appimage
-        continue-on-error: true
-        
+           name: eden-common-mesa-appimage
+           
+      - uses: actions/download-artifact@v4.3.0
+        with:
+           name: eden-common-light-appimage
+           
+      - uses: actions/download-artifact@v4.3.0
+        with:
+           name: eden-aarch64-mesa-appimage
+           
+      - uses: actions/download-artifact@v4.3.0
+        with:
+           name: eden-aarch64-light-appimage
+           
       - uses: actions/download-artifact@v4.3.0
         with:
            name: eden-android-Replace
-        continue-on-error: true
         
       - uses: actions/download-artifact@v4.3.0
         with:
            name: eden-android-Coexist
-        continue-on-error: true
         
       - uses: actions/download-artifact@v4.3.0
         with:
            name: eden-windows-msvc-x86_64
-        continue-on-error: true
         
-      - uses: actions/download-artifact@v4.3.0
-        with:
-           name: eden-windows-msvc-x86_arm64
-        continue-on-error: true
+#      - uses: actions/download-artifact@v4.3.0
+#        with:
+#           name: eden-windows-msvc-x86_arm64
+#        continue-on-error: true
         
       - uses: actions/download-artifact@v4.3.0
         with:
            name: eden-macos-x86_64
-        continue-on-error: true
         
       - uses: actions/download-artifact@v4.3.0
         with:
            name: eden-macos-arm64
-        continue-on-error: true
         
       - uses: actions/download-artifact@v4.3.0
         with:
@@ -316,15 +324,15 @@ jobs:
           cat changelog >> "${GITHUB_ENV}"
           echo "EOF" >> "${GITHUB_ENV}"    
 
-      - name: Delete same tag release
-        run: |
-          gh release delete "${{ env.TAG }}" --repo "${GITHUB_REPOSITORY}" --cleanup-tag  -y
-          sleep 10
-        env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        continue-on-error: true
+#      - name: Delete same tag release
+#        run: |
+#          gh release delete "${{ env.TAG }}" --repo "${GITHUB_REPOSITORY}" --cleanup-tag  -y
+#          sleep 10
+#        env:
+#          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+#        continue-on-error: true
 
-      - name: Build Releaser
+      - name: Release Eden
         uses: softprops/action-gh-release@v2
         with:
           name: "Eden Nightly Release: ${{ env.COUNT }}"

--- a/README.md
+++ b/README.md
@@ -26,29 +26,28 @@ This repository provides **nightly releases** of **Eden** for the following plat
 
 ---------------------------------------------------------------
 
-### Linux Builds
+### 🐧 Linux Builds
 
-The **AppImage** for Linux is built using [**Sharun**](https://github.com/VHSgunzo/sharun) with several compliler optimization flags targeting:
+The **AppImage** for Linux is built with several compliler optimization flags targeting:
 
 - **Steam Deck** — optimized for `znver2` (Zen 2)
 - **AArch64 devices** — compatible with `aarch64` architecture
 - **Modern x86_64 CPUs** — optimized for `x86-64-v3` (via the Common Build)
 
-Each AppImage is bundled with **Mesa drivers** to ensure maximum compatibility and may provide the latest fixes for certain games.
+AppImages built using [**Sharun**](https://github.com/VHSgunzo/sharun) are bundled with **Mesa drivers** to ensure maximum compatibility — similar to Eden’s official releases and may include the latest fixes for certain games (though untested).
 
-A **Light version** is also available, which excludes Mesa drivers for a more lightweight build and relies on the system’s native graphics drivers.
+A **Light version** is also available, built with **linuxdeploy**. It does **not** include Mesa drivers, resulting in a more lightweight build that relies on the system’s native graphics drivers — similar to many other emulators.
 > ⚠️ The `aarch64` build is based on a workaround change and is intended for testing purposes only.
 >
 > If you encounter any problems, you're welcome to open an issue.
-
 
 These builds should work on any linux distro.
 
 ---------------------------------------------------------------
 
-### Android Builds
+### 🤖 Android Builds
 
-Eden for Android is available in two versions:
+Eden nightly for Android is available in two versions:
 
 - **Replace** Build
   
@@ -60,7 +59,7 @@ Uses a nightly application ID, allowing it to coexist with the official Eden rel
 
 ---------------------------------------------------------------
 
-### Windows Builds
+### 🪟 Windows Builds
 
 > ⚠️ The Windows **ARM64** build is based on **work-in-progress (WIP)** changes and is intended for testing purposes only.
 >
@@ -68,7 +67,7 @@ Uses a nightly application ID, allowing it to coexist with the official Eden rel
 
 ---------------------------------------------------------------
 
-### MacOS Builds
+### 🍎 MacOS Builds
 
 > ⚠️ MacOS builds are **not officially supported** at the moment and are provided for **testing purposes only**.
 >   

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ The **AppImage** for Linux is built using [**Sharun**](https://github.com/VHSgun
 - **AArch64 devices** — compatible with `aarch64` architecture
 - **Modern x86_64 CPUs** — optimized for `x86-64-v3` (via the Common Build)
 
-Each AppImage is bundled with **Mesa drivers** to ensure maximum compatibility and may provide the latest fixes for certain games.  
+Each AppImage is bundled with **Mesa drivers** to ensure maximum compatibility and may provide the latest fixes for certain games.
+
+A **Light version** is also available, which excludes Mesa drivers for a more lightweight build and relies on the system’s native graphics drivers.
 > ⚠️ The `aarch64` build is based on a workaround change and is intended for testing purposes only.
 >
 > If you encounter any problems, you're welcome to open an issue.

--- a/changelog.sh
+++ b/changelog.sh
@@ -63,14 +63,14 @@ echo >> "$CHANGELOG_FILE"
 echo "## Nightly Release: ${COUNT}" >> "$CHANGELOG_FILE"
 echo "| Platform | Target / Arch | |" >> "$CHANGELOG_FILE"
 echo "|--|--|--|" >> "$CHANGELOG_FILE"
-echo "| Linux | **Appimages with mesa**<br>────────────────<br>" \
-"[\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-x86_64_v3.AppImage)<br><br>" \
-"[\`Steamdeck x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-x86_64.AppImage)<br><br>" \
-"[\`aarch64 (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-aarch64.AppImage) | " \
-"**Appimages without mesa**<br>────────────────<br>" \
-"[\`Common-light x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-light-x86_64_v3.AppImage)<br><br>" \
-"[\`Steamdeck-light x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-light-x86_64.AppImage)<br><br>" \
-"[\`aarch64-light (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-light-aarch64.AppImage) |" >> "$CHANGELOG_FILE"
+echo "| Linux | **Appimages with mesa**<br>────────────────<br>\
+[\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-x86_64_v3.AppImage)<br><br>\
+[\`Steamdeck x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-x86_64.AppImage)<br><br>\
+[\`aarch64 (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-aarch64.AppImage) | \
+**Appimages without mesa**<br>────────────────<br>\
+[\`Common-light x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-light-x86_64_v3.AppImage)<br><br>\
+[\`Steamdeck-light x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-light-x86_64.AppImage)<br><br>\
+[\`aarch64-light (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-light-aarch64.AppImage) |" >> "$CHANGELOG_FILE"
 echo "| Android | [\`Coexist\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Coexist.apk)<br><br>[\`Replace\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Replace.apk) |" >> "$CHANGELOG_FILE"
 echo "| Windows | [~~ARM64~~]*(Unavailable)*<br><br>[\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Windows-x86_64.7z) |" >> "$CHANGELOG_FILE"
 echo "| MacOS (Experimental) | [\`arm64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-MacOS-arm64.7z)<br><br>[\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-MacOS-x86_64.7z) |" >> "$CHANGELOG_FILE"

--- a/changelog.sh
+++ b/changelog.sh
@@ -26,6 +26,12 @@ CHANGELOG_FILE=~/changelog
 BASE_COMMIT_URL="https://git.eden-emu.dev/eden-emu/eden/commit"
 BASE_COMPARE_URL="https://git.eden-emu.dev/eden-emu/eden/compare"
 BASE_DOWNLOAD_URL="https://github.com/pflyly/eden-nightly/releases/download"
+
+# Fallback if OLD_HASH is empty or null
+if [ -z "$OLD_HASH" ]; then
+  echo "OLD_HASH is empty, falling back to current HASH"
+  OLD_HASH="$HASH"
+fi
 START_COUNT=$(git rev-list --count "$OLD_HASH")
 i=$((START_COUNT + 1))
 
@@ -55,9 +61,16 @@ echo >> "$CHANGELOG_FILE"
 
 # Generate release table
 echo "## Nightly Release: ${COUNT}" >> "$CHANGELOG_FILE"
-echo "| Platform | Target / Arch |" >> "$CHANGELOG_FILE"
-echo "|--|--|" >> "$CHANGELOG_FILE"
-echo "| Linux | [\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-x86_64_v3.AppImage)<br><br>[\`Steamdeck x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-x86_64.AppImage)<br><br>[\`aarch64 (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-aarch64.AppImage) |" >> "$CHANGELOG_FILE"
+echo "| Platform | Target / Arch | |" >> "$CHANGELOG_FILE"
+echo "|--|--|--|" >> "$CHANGELOG_FILE"
+echo "| Linux | **Appimages with mesa**<br>────────────────<br>" \
+"[\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-x86_64_v3.AppImage)<br><br>" \
+"[\`Steamdeck x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-x86_64.AppImage)<br><br>" \
+"[\`aarch64 (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-aarch64.AppImage) | " \
+"**Appimages without mesa**<br>────────────────<br>" \
+"[\`Common-light x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-light-x86_64_v3.AppImage)<br><br>" \
+"[\`Steamdeck-light x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-light-x86_64.AppImage)<br><br>" \
+"[\`aarch64-light (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-light-aarch64.AppImage) |" >> "$CHANGELOG_FILE"
 echo "| Android | [\`Coexist\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Coexist.apk)<br><br>[\`Replace\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Replace.apk) |" >> "$CHANGELOG_FILE"
 echo "| Windows | [~~ARM64~~]*(Unavailable)*<br><br>[\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Windows-x86_64.7z) |" >> "$CHANGELOG_FILE"
 echo "| MacOS (Experimental) | [\`arm64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-MacOS-arm64.7z)<br><br>[\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-MacOS-x86_64.7z) |" >> "$CHANGELOG_FILE"

--- a/changelog.sh
+++ b/changelog.sh
@@ -63,14 +63,14 @@ echo >> "$CHANGELOG_FILE"
 echo "## Nightly Release: ${COUNT}" >> "$CHANGELOG_FILE"
 echo "| Platform | Target / Arch | |" >> "$CHANGELOG_FILE"
 echo "|--|--|--|" >> "$CHANGELOG_FILE"
-echo "| Linux | **Appimages with mesa**<br>────────────────<br>\
-[\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-x86_64_v3.AppImage)<br><br>\
-[\`Steamdeck x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-x86_64.AppImage)<br><br>\
-[\`aarch64 (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-aarch64.AppImage) | \
-**Appimages without mesa**<br>────────────────<br>\
-[\`Common-light x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-light-x86_64_v3.AppImage)<br><br>\
-[\`Steamdeck-light x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-light-x86_64.AppImage)<br><br>\
-[\`aarch64-light (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-light-aarch64.AppImage) |" >> "$CHANGELOG_FILE"
+echo "| Linux | **Full Builds (Sharun, with Mesa)**<br><sub>Best compatibility — includes Mesa drivers</sub><br>────────────────<br>\
+[\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-x86_64_v3.AppImage) ~ 92 MB<br><br>\
+[\`Steamdeck x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-x86_64.AppImage) ~ 92 MB<br><br>\
+[\`aarch64 (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-aarch64.AppImage) ~ 88 MB | \
+**Light Builds (linuxdeploy, no Mesa)**<br><sub>Lighter size — uses system drivers</sub><br>────────────────<br>\
+[\`Common-light x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Common-light-x86_64_v3.AppImage) ~ 36 MB<br><br>\
+[\`Steamdeck-light x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Steamdeck-light-x86_64.AppImage) ~ 36 MB<br><br>\
+[\`aarch64-light (Experimental)\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Linux-light-aarch64.AppImage) ~ 35 MB |" >> "$CHANGELOG_FILE"
 echo "| Android | [\`Coexist\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Coexist.apk)<br><br>[\`Replace\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Replace.apk) |" >> "$CHANGELOG_FILE"
 echo "| Windows | [~~ARM64~~]*(Unavailable)*<br><br>[\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Windows-x86_64.7z) |" >> "$CHANGELOG_FILE"
 echo "| MacOS (Experimental) | [\`arm64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-MacOS-arm64.7z)<br><br>[\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-MacOS-x86_64.7z) |" >> "$CHANGELOG_FILE"

--- a/eden-appimage.sh
+++ b/eden-appimage.sh
@@ -81,9 +81,13 @@ if [ "$1" != 'aarch64' ]; then
 fi
 
 cd ../..
-# Use sharun to generate AppDir
+# Use sharun to generate AppDir with mesa drivers
 chmod +x ./sharun.sh
 ./sharun.sh ./eden/build
+
+# Use linuxdeploy to generate AppDir without mesa drivers
+chmod +x ./linuxdeploy.sh
+./linuxdeploy.sh ./eden/build
 
 # Prepare uruntime
 wget -q "$URUNTIME" -O ./uruntime

--- a/eden-appimage.sh
+++ b/eden-appimage.sh
@@ -103,7 +103,7 @@ echo "Generating zsync file for $MESA_APPIMAGE"
 zsyncmake -v "$MESA_APPIMAGE" -u "$MESA_APPIMAGE"
 
 mkdir -p mesa
-mv "${MESA_APPIMAGE}"* mesa/
+mv -v "${MESA_APPIMAGE}"* mesa/
 
 echo "Generating AppImage without mesa"
 LIGHT_APPIMAGE="Eden-${COUNT}-${TARGET}-light-${ARCH}.AppImage"
@@ -114,6 +114,6 @@ echo "Generating zsync file for $LIGHT_APPIMAGE"
 zsyncmake -v "$LIGHT_APPIMAGE" -u "$LIGHT_APPIMAGE"
 
 mkdir -p light
-mv "${LIGHT_APPIMAGE}"* light/
+mv -v "${LIGHT_APPIMAGE}"* light/
 
 echo "All Done!"

--- a/eden-appimage.sh
+++ b/eden-appimage.sh
@@ -56,7 +56,6 @@ cd build
 cmake .. -GNinja \
     -DYUZU_USE_BUNDLED_VCPKG=OFF \
     -DYUZU_USE_BUNDLED_QT=OFF \
-    -DUSE_SYSTEM_QT=ON \
     -DYUZU_TESTS=OFF \
     -DYUZU_CHECK_SUBMODULES=OFF \
     -DYUZU_USE_FASTER_LD=ON \
@@ -94,18 +93,27 @@ chmod +x ./uruntime
 echo "Adding update information \"$UPINFO\" to runtime..."
 ./uruntime --appimage-addupdinfo "$UPINFO"
 
-# Turn AppDir into appimage
+# Turn AppDir into appimage and upload seperately
 echo "Generating AppImage with mesa"
+MESA_APPIMAGE="Eden-${COUNT}-${TARGET}-${ARCH}.AppImage"
 ./uruntime --appimage-mkdwarfs -f --set-owner 0 --set-group 0 --no-history --no-create-timestamp --compression zstd:level=22 -S26 -B32 \
---header uruntime -i ./eden/build/mesa/AppDir -o Eden-"${COUNT}"-"${TARGET}"-"$ARCH".AppImage
+--header uruntime -i ./eden/build/mesa/AppDir -o "$MESA_APPIMAGE"
 
-# echo "Generating AppImage without mesa"
+echo "Generating zsync file for $MESA_APPIMAGE"
+zsyncmake -v "$MESA_APPIMAGE" -u "$MESA_APPIMAGE"
+
+mkdir -p mesa
+mv "${MESA_APPIMAGE}"* mesa/
+
+echo "Generating AppImage without mesa"
+LIGHT_APPIMAGE="Eden-${COUNT}-${TARGET}-light-${ARCH}.AppImage"
 ./uruntime --appimage-mkdwarfs -f --set-owner 0 --set-group 0 --no-history --no-create-timestamp --compression zstd:level=22 -S26 -B32 \
---header uruntime -i ./eden/build/light/AppDir -o Eden-"${COUNT}"-"${TARGET}"-light-"$ARCH".AppImage
+--header uruntime -i ./eden/build/light/AppDir -o "$LIGHT_APPIMAGE"
 
-for appimage in *.AppImage; do
-  echo "Generating zsync file for $appimage"
-  zsyncmake -v "$appimage" -u "$appimage"
-done
+echo "Generating zsync file for $LIGHT_APPIMAGE"
+zsyncmake -v "$LIGHT_APPIMAGE" -u "$LIGHT_APPIMAGE"
+
+mkdir -p light
+mv "${LIGHT_APPIMAGE}"* light/
 
 echo "All Done!"

--- a/eden-appimage.sh
+++ b/eden-appimage.sh
@@ -100,8 +100,8 @@ echo "Generating AppImage with mesa"
 --header uruntime -i ./eden/build/mesa/AppDir -o Eden-"${COUNT}"-"${TARGET}"-"$ARCH".AppImage
 
 # echo "Generating AppImage without mesa"
-#./uruntime --appimage-mkdwarfs -f --set-owner 0 --set-group 0 --no-history --no-create-timestamp --compression zstd:level=22 -S26 -B32 \
-#--header uruntime -i ./eden/build/light/AppDir -o Eden-"${COUNT}"-"${TARGET}"-light-"$ARCH".AppImage
+./uruntime --appimage-mkdwarfs -f --set-owner 0 --set-group 0 --no-history --no-create-timestamp --compression zstd:level=22 -S26 -B32 \
+--header uruntime -i ./eden/build/light/AppDir -o Eden-"${COUNT}"-"${TARGET}"-light-"$ARCH".AppImage
 
 for appimage in *.AppImage; do
   echo "Generating zsync file for $appimage"

--- a/linuxdeploy.sh
+++ b/linuxdeploy.sh
@@ -6,7 +6,7 @@ export APPIMAGE_EXTRACT_AND_RUN=1
 export ARCH=$(uname -m)
 
 BUILD_DIR=$(realpath "$1")
-APPDIR="${BUILD_DIR}/AppDir"
+APPDIR="${BUILD_DIR}/light/AppDir"
 
 cd "${BUILD_DIR}"
 
@@ -29,10 +29,10 @@ export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so;libqxcb
 export EXTRA_QT_PLUGINS="svg;wayland-decoration-client;wayland-graphics-integration-client;wayland-shell-integration;waylandcompositor;xcb-gl-integration;platformthemes/libqt6ct.so"
 
 # start to deploy
-NO_STRIP=1 ./linuxdeploy --appdir ./AppDir --plugin qt --plugin checkrt
+NO_STRIP=1 ./linuxdeploy --appdir ./light/AppDir --plugin qt --plugin checkrt
 
 # remove libvulkan because it causes issues with gamescope
-rm -fv ./AppDir/usr/lib/libvulkan.so*
+rm -fv ./light/AppDir/usr/lib/libvulkan.so*
 
 # Bundle libsdl3 to AppDir, needed for steamdeck
-cp /usr/lib/libSDL3.so* ./AppDir/usr/lib/
+cp /usr/lib/libSDL3.so* ./light/AppDir/usr/lib/

--- a/sharun.sh
+++ b/sharun.sh
@@ -80,4 +80,4 @@ genarate_appdir() {
 genarate_appdir "mesa" MESA_FLAGS[@] MESA_EXTRA_LIBS[@]
 
 # Genarate Appdir without mesa drivers for lightweight
-# genarate_appdir "light" LIGHT_FLAGS[@] EMPTY[@]
+genarate_appdir "light" LIGHT_FLAGS[@] EMPTY[@]

--- a/sharun.sh
+++ b/sharun.sh
@@ -80,4 +80,4 @@ genarate_appdir() {
 genarate_appdir "mesa" MESA_FLAGS[@] MESA_EXTRA_LIBS[@]
 
 # Genarate Appdir without mesa drivers for lightweight
-genarate_appdir "light" LIGHT_FLAGS[@] EMPTY[@]
+# genarate_appdir "light" LIGHT_FLAGS[@] EMPTY[@]


### PR DESCRIPTION
since we have a release table now,  we can add this verison more organized
tested common-light and steamdeck-light on my steamdeck, all seems ok.