### PR TITLE
use `lsfg-vk` upstream releases

### DIFF
--- a/linux-dependencies.sh
+++ b/linux-dependencies.sh
@@ -79,18 +79,6 @@ pacman -Syu --noconfirm \
 	zip \
 	zsync
 
-# build and installlsfg-vk
-git clone https://github.com/PancakeTAS/lsfg-vk.git ./lsfg && (
-	cd ./lsfg
-	CC=clang CXX=clang++ cmake \
-		-B build                    \
-		-G Ninja                    \
-		-DCMAKE_BUILD_TYPE=Release  \
-		-DCMAKE_INSTALL_PREFIX=/usr
-	cmake --build build
-	cmake --install build
-)
-
 
 case "$ARCH" in
 	'x86_64')  

--- a/linuxdeploy.sh
+++ b/linuxdeploy.sh
@@ -38,9 +38,12 @@ rm -fv ./light/AppDir/usr/lib/libvulkan.so*
 cp /usr/lib/libSDL3.so* ./light/AppDir/usr/lib/
 
 # include lsfg-vk
-cp -v /usr/lib/liblsfg-vk.so ./light/AppDir/usr/lib/
-mkdir -p ./light/AppDir/usr/share/vulkan/implicit_layer.d/
-cp -v /usr/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json ./light/AppDir/usr/share/vulkan/implicit_layer.d/
+(
+  cd ./light/AppDir/usr
+  wget --retry-connrefused --tries=30 "https://pancake.gay/lsfg-vk/lsfg-vk.zip"
+  unzip -o ./lsfg-vk.zip
+  rm -f ./lsfg-vk.zip
+)
 
 # manually set XDG_DATA_DIRS to make sure lsfg-vk included
 sed -i '/^this_dir=.*$/a\

--- a/sharun.sh
+++ b/sharun.sh
@@ -45,10 +45,10 @@ xvfb-run -a -- ./lib4bin -p -v -e -s -k \
     /usr/lib/libdecor-0.so*
 
 # include lsfg-vk
-cp -v /usr/lib/liblsfg-vk.so ./shared/lib
-cp -rv /usr/share/vulkan/implicit_layer.d/ ./share/vulkan
+wget --retry-connrefused --tries=30 "https://pancake.gay/lsfg-vk/lsfg-vk.zip"
+unzip -o ./lsfg-vk.zip
 sed -i 's|../../../lib/||' ./share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json
-
+rm -f ./lsfg-vk.zip
 ln -fv ./sharun ./AppRun
 ./sharun -g
 


### PR DESCRIPTION
Also now lsfg works with the latest version of lossless scaling. (and only works with that one it seems). 

So you have to select latest in Steam and stop using legacy version. 

Tested the common appimage working, didn't test linuxdeploy ones. 