### PR TITLE
include `lsfg-vk` only in `x86_64`

### DIFF
--- a/linuxdeploy.sh
+++ b/linuxdeploy.sh
@@ -38,12 +38,14 @@ rm -fv ./light/AppDir/usr/lib/libvulkan.so*
 cp /usr/lib/libSDL3.so* ./light/AppDir/usr/lib/
 
 # include lsfg-vk
-(
-  cd ./light/AppDir/usr
-  wget --retry-connrefused --tries=30 "https://pancake.gay/lsfg-vk/lsfg-vk.zip"
-  unzip -o ./lsfg-vk.zip
-  rm -f ./lsfg-vk.zip
-)
+if [ "$ARCH" = "x86_64" ]; then
+  (
+    cd ./light/AppDir/usr
+    wget --retry-connrefused --tries=30 "https://pancake.gay/lsfg-vk/lsfg-vk.zip"
+    unzip -o ./lsfg-vk.zip
+    rm -f ./lsfg-vk.zip
+  )
+fi
 
 # manually set XDG_DATA_DIRS to make sure lsfg-vk included
 sed -i '/^this_dir=.*$/a\

--- a/sharun.sh
+++ b/sharun.sh
@@ -45,10 +45,12 @@ xvfb-run -a -- ./lib4bin -p -v -e -s -k \
     /usr/lib/libdecor-0.so*
 
 # include lsfg-vk
-wget --retry-connrefused --tries=30 "https://pancake.gay/lsfg-vk/lsfg-vk.zip"
-unzip -o ./lsfg-vk.zip
-sed -i 's|../../../lib/||' ./share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json
-rm -f ./lsfg-vk.zip
+if [ "$ARCH" = "x86_64" ]; then
+    wget --retry-connrefused --tries=30 "https://pancake.gay/lsfg-vk/lsfg-vk.zip"
+    unzip -o ./lsfg-vk.zip
+    sed -i 's|../../../lib/||' ./share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json
+    rm -f ./lsfg-vk.zip
+fi
 ln -fv ./sharun ./AppRun
 ./sharun -g
 


### PR DESCRIPTION
* Upstream only releases `lsfg-vk` for `x86_64`. 

* We also can't build it for `aarch64` because lossless scaling itself does not have `aarch64` releases.