### PR TITLE
add Android pgo, again, but natively

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -157,10 +157,12 @@ jobs:
     strategy:
       matrix:
         target: [Replace, Coexist, Optimised]
+        optimize: [normal, PGO]
     continue-on-error: true
-    name: "Android (${{ matrix.target }})"
+    name: "Android ${{ matrix.target }} (${{ matrix.optimize }})"
     env:
       TARGET: ${{ matrix.target }}
+      OPTIMIZE: ${{ matrix.optimize }}
     steps:
       - uses: actions/checkout@v5.0.0
 
@@ -173,15 +175,15 @@ jobs:
         run: |
           git clone 'https://git.eden-emu.dev/eden-emu/eden.git' ./eden
 
-      - name: Restore cpm cache for ${{ matrix.target }}
+      - name: Restore cpm cache
         uses: actions/cache/restore@v4
         id: restore-cpm-cache
         with:
           path: |
             ${{ github.workspace }}/eden/.cache
-          key: ${{ runner.os }}-android-cpm-${{ matrix.target }}-${{ github.sha }}
+          key: ${{ runner.os }}-android-cpm-${{ matrix.target }}-${{ matrix.optimize }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-android-cpm-${{ matrix.target }}-
+            ${{ runner.os }}-android-cpm-${{ matrix.target }}-${{ matrix.optimize }}-
 
       - name: Compile Eden android
         run: |
@@ -191,7 +193,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: eden-android-${{ matrix.target }}
+          name: eden-android-${{ matrix.target }}-${{ matrix.optimize }}
           path: eden/src/android/artifacts/
 
       - name: Save cpm cache for ${{ matrix.target }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -15,6 +15,7 @@ on:
           - appimage
           - macos
           - android
+          - android_pgo_gen
           - freebsd
           - info
         default: 'all'
@@ -200,6 +201,39 @@ jobs:
           path: |
             ${{ github.workspace }}/eden/.cache
           key: ${{ steps.restore-cpm-cache.outputs.cache-primary-key }}
+
+  android_pgo_gen:
+    if: github.event.inputs.job_to_run == 'android_pgo_gen'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [pgogen]
+    continue-on-error: true
+    name: "Android (${{ matrix.target }})"
+    env:
+      TARGET: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v5.0.0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install glslang-tools libvulkan-dev python3-requests -y
+
+      - name: Clone Eden
+        run: |
+          git clone 'https://git.eden-emu.dev/eden-emu/eden.git' ./eden
+
+      - name: Compile Eden android
+        run: |
+          chmod +x ./eden-android.sh
+          ./eden-android.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: eden-android-${{ matrix.target }}
+          path: eden/src/android/artifacts/
 
   windows:
     if: github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'windows'

--- a/changelog.sh
+++ b/changelog.sh
@@ -81,7 +81,10 @@ echo "| Linux (AppBundle) | [\`Common x86_64_v3\`](${BASE_DOWNLOAD_URL}/${TAG}/E
 echo "| FreeBSD | [\`amd64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-FreeBSD-amd64.tar.xz) | [\`amd64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-FreeBSD-PGO-amd64.tar.xz) | " >> "$CHANGELOG_FILE"
 echo "| Android | [\`Replace\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Replace.apk)<br><br>\
 [\`Coexist\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Coexist.apk)<br><br>\
-[\`Optimised\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Optimised.apk) |" >> "$CHANGELOG_FILE"
+[\`Optimised\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Optimised.apk) | \
+[\`Replace-PGO\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Replace-PGO.apk)<br><br>\
+[\`Coexist-PGO\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Coexist-PGO.apk)<br><br>\
+[\`Optimised-PGO\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Android-Optimised-PGO.apk) |" >> "$CHANGELOG_FILE"
 echo "| Windows (MSVC) | **7z**<br>────────────────<br>\
 [\`x86_64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Windows-msvc-x86_64.7z)<br><br>\
 [\`arm64\`](${BASE_DOWNLOAD_URL}/${TAG}/Eden-${COUNT}-Windows-msvc-arm64.7z)<br><br>\

--- a/eden-android.sh
+++ b/eden-android.sh
@@ -2,6 +2,10 @@
 
 cd ./eden
 
+if [ "$TARGET" = "pgogen" ]; then
+	git apply ../patches/android_pgo_gen.patch
+fi
+
 if [ "$TARGET" = "Coexist" ]; then
     # Change the App name and application ID to make it coexist with official build
     sed -i 's/applicationId = "dev\.eden\.eden_emulator"/applicationId = "dev.eden.eden_emulator.nightly"/' src/android/app/build.gradle.kts

--- a/eden-android.sh
+++ b/eden-android.sh
@@ -10,6 +10,7 @@ fi
 if [ "$OPTIMIZE" = "PGO" ]; then
 	# pacth to use prfodata
 	git apply ../patches/android_pgo_use.patch
+	unzip ../pgo/android.profdata.zip -d ../pgo
 fi
 
 if [ "$TARGET" = "Coexist" ]; then

--- a/eden-android.sh
+++ b/eden-android.sh
@@ -3,12 +3,18 @@
 cd ./eden
 
 if [ "$TARGET" = "pgogen" ]; then
+	# patch to generate profraw
 	git apply ../patches/android_pgo_gen.patch
+fi
+
+if [ "$OPTIMIZE" = "PGO" ]; then
+	# pacth to use prfodata
+	git apply ../patches/android_pgo_use.patch
 fi
 
 if [ "$TARGET" = "Coexist" ]; then
     # Change the App name and application ID to make it coexist with official build
-    sed -i 's/applicationId = "dev\.eden\.eden_emulator"/applicationId = "dev.eden.eden_emulator.nightly"/' src/android/app/build.gradle.kts
+    sed -i 's/applicationId = "dev\.eden\.eden_emulator"/applicationId = "dev.eden_nightly.eden_emulator"/' src/android/app/build.gradle.kts
     sed -i 's/resValue("string", "app_name_suffixed", "Eden")/resValue("string", "app_name_suffixed", "Eden Nightly")/' src/android/app/build.gradle.kts
     sed -i 's|<string name="app_name"[^>]*>.*</string>|<string name="app_name" translatable="false">Eden Nightly</string>|' src/android/app/src/main/res/values/strings.xml
 fi        
@@ -20,7 +26,12 @@ if [ "$TARGET" = "Optimised" ]; then
 fi 
 
 COUNT="$(git rev-list --count HEAD)"
-APK_NAME="Eden-${COUNT}-Android-${TARGET}"
+
+if [ "$OPTIMIZE" = "PGO" ]; then
+	APK_NAME="Eden-${COUNT}-Android-${TARGET}-${OPTIMIZE}"
+else
+	APK_NAME="Eden-${COUNT}-Android-${TARGET}"
+fi
 
 cd src/android
 chmod +x ./gradlew

--- a/patches/android_pgo_gen.patch
+++ b/patches/android_pgo_gen.patch
@@ -1,13 +1,14 @@
 diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
-index e8d8141711..d30cfc503b 100644
+index e8d8141711..9453364972 100644
 --- a/src/android/app/build.gradle.kts
 +++ b/src/android/app/build.gradle.kts
-@@ -178,7 +178,9 @@ android {
+@@ -178,7 +178,10 @@ android {
                      "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
                      "-DBUILD_TESTING=OFF",
                      "-DYUZU_TESTS=OFF",
 -                    "-DDYNARMIC_TESTS=OFF"
 +                    "-DDYNARMIC_TESTS=OFF",
++                    "-DCMAKE_BUILD_TYPE=Release",
 +                    "-DCMAKE_C_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p.profraw",
 +                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p.profraw"
                  )

--- a/patches/android_pgo_gen.patch
+++ b/patches/android_pgo_gen.patch
@@ -1,5 +1,5 @@
 diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
-index e8d8141711..4975087d89 100644
+index e8d8141711..59c797c3de 100644
 --- a/src/android/app/build.gradle.kts
 +++ b/src/android/app/build.gradle.kts
 @@ -178,7 +178,9 @@ android {
@@ -8,8 +8,8 @@ index e8d8141711..4975087d89 100644
                      "-DYUZU_TESTS=OFF",
 -                    "-DDYNARMIC_TESTS=OFF"
 +                    "-DDYNARMIC_TESTS=OFF",
-+                    "-DCMAKE_C_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden_%m.profraw",
-+                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden_%m.profraw"
++                    "-DCMAKE_C_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p-%c.profraw",
++                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p-%c.profraw"
                  )
  
                  abiFilters("arm64-v8a")

--- a/patches/android_pgo_gen.patch
+++ b/patches/android_pgo_gen.patch
@@ -1,5 +1,5 @@
 diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
-index e8d8141711..59c797c3de 100644
+index e8d8141711..d30cfc503b 100644
 --- a/src/android/app/build.gradle.kts
 +++ b/src/android/app/build.gradle.kts
 @@ -178,7 +178,9 @@ android {
@@ -8,8 +8,8 @@ index e8d8141711..59c797c3de 100644
                      "-DYUZU_TESTS=OFF",
 -                    "-DDYNARMIC_TESTS=OFF"
 +                    "-DDYNARMIC_TESTS=OFF",
-+                    "-DCMAKE_C_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p-%c.profraw",
-+                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p-%c.profraw"
++                    "-DCMAKE_C_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p.profraw",
++                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden-%p.profraw"
                  )
  
                  abiFilters("arm64-v8a")

--- a/patches/android_pgo_gen.patch
+++ b/patches/android_pgo_gen.patch
@@ -1,0 +1,42 @@
+diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
+index e8d8141711..4975087d89 100644
+--- a/src/android/app/build.gradle.kts
++++ b/src/android/app/build.gradle.kts
+@@ -178,7 +178,9 @@ android {
+                     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                     "-DBUILD_TESTING=OFF",
+                     "-DYUZU_TESTS=OFF",
+-                    "-DDYNARMIC_TESTS=OFF"
++                    "-DDYNARMIC_TESTS=OFF",
++                    "-DCMAKE_C_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden_%m.profraw",
++                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-generate=/sdcard/Android/data/dev.eden.eden_emulator/files/eden_%m.profraw"
+                 )
+ 
+                 abiFilters("arm64-v8a")
+diff --git a/src/android/app/src/main/jni/native.cpp b/src/android/app/src/main/jni/native.cpp
+index 306b7e2a4c..db7bc47e60 100644
+--- a/src/android/app/src/main/jni/native.cpp
++++ b/src/android/app/src/main/jni/native.cpp
+@@ -304,6 +304,8 @@ Core::SystemResultStatus EmulationSession::InitializeEmulation(const std::string
+     return Core::SystemResultStatus::Success;
+ }
+ 
++extern "C" int __llvm_profile_write_file(void);
++
+ void EmulationSession::ShutdownEmulation() {
+     std::scoped_lock lock(m_mutex);
+ 
+@@ -328,11 +330,13 @@ void EmulationSession::ShutdownEmulation() {
+         m_load_result = Core::SystemResultStatus::ErrorNotInitialized;
+         m_window.reset();
+         OnEmulationStopped(Core::SystemResultStatus::Success);
++        __llvm_profile_write_file();
+         return;
+     }
+ 
+     // Tear down the render window.
+     m_window.reset();
++    __llvm_profile_write_file();
+ }
+ 
+ void EmulationSession::PauseEmulation() {

--- a/patches/android_pgo_use.patch
+++ b/patches/android_pgo_use.patch
@@ -1,13 +1,14 @@
 diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
-index e8d8141711..d5042c7b11 100644
+index e8d8141711..13db4428dc 100644
 --- a/src/android/app/build.gradle.kts
 +++ b/src/android/app/build.gradle.kts
-@@ -178,7 +178,11 @@ android {
+@@ -178,7 +178,12 @@ android {
                      "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
                      "-DBUILD_TESTING=OFF",
                      "-DYUZU_TESTS=OFF",
 -                    "-DDYNARMIC_TESTS=OFF"
 +                    "-DDYNARMIC_TESTS=OFF",
++                    "-DCMAKE_BUILD_TYPE=Release",
 +                    "-DCMAKE_C_FLAGS_RELEASE=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
 +                    "-DCMAKE_CXX_FLAGS_RELEASE=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
 +                    "-DCMAKE_SHARED_LINKER_FLAGS_RELEASE=-flto=thin",

--- a/patches/android_pgo_use.patch
+++ b/patches/android_pgo_use.patch
@@ -1,0 +1,17 @@
+diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
+index e8d8141711..d5042c7b11 100644
+--- a/src/android/app/build.gradle.kts
++++ b/src/android/app/build.gradle.kts
+@@ -178,7 +178,11 @@ android {
+                     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                     "-DBUILD_TESTING=OFF",
+                     "-DYUZU_TESTS=OFF",
+-                    "-DDYNARMIC_TESTS=OFF"
++                    "-DDYNARMIC_TESTS=OFF",
++                    "-DCMAKE_C_FLAGS_RELEASE=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
++                    "-DCMAKE_CXX_FLAGS_RELEASE=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
++                    "-DCMAKE_SHARED_LINKER_FLAGS_RELEASE=-flto=thin",
++                    "-DCMAKE_EXE_LINKER_FLAGS_RELEASE=-flto=thin"
+                 )
+ 
+                 abiFilters("arm64-v8a")

--- a/patches/android_pgo_use.patch
+++ b/patches/android_pgo_use.patch
@@ -1,5 +1,5 @@
 diff --git a/src/android/app/build.gradle.kts b/src/android/app/build.gradle.kts
-index e8d8141711..13db4428dc 100644
+index e8d8141711..f6816f7dc8 100644
 --- a/src/android/app/build.gradle.kts
 +++ b/src/android/app/build.gradle.kts
 @@ -178,7 +178,12 @@ android {
@@ -9,10 +9,10 @@ index e8d8141711..13db4428dc 100644
 -                    "-DDYNARMIC_TESTS=OFF"
 +                    "-DDYNARMIC_TESTS=OFF",
 +                    "-DCMAKE_BUILD_TYPE=Release",
-+                    "-DCMAKE_C_FLAGS_RELEASE=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
-+                    "-DCMAKE_CXX_FLAGS_RELEASE=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
-+                    "-DCMAKE_SHARED_LINKER_FLAGS_RELEASE=-flto=thin",
-+                    "-DCMAKE_EXE_LINKER_FLAGS_RELEASE=-flto=thin"
++                    "-DCMAKE_C_FLAGS=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
++                    "-DCMAKE_CXX_FLAGS=-fprofile-instr-use=$projectDir/../../../../pgo/android.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -flto=thin",
++                    "-DCMAKE_SHARED_LINKER_FLAGS=-flto=thin",
++                    "-DCMAKE_EXE_LINKER_FLAGS=-flto=thin"
                  )
  
                  abiFilters("arm64-v8a")


### PR DESCRIPTION
Instead of using profdata generated from a steamdeck via clang, which has already been used by windows clang, swtiched to try to generate android native profdata from a real Android phone.

Added a seperated job to compile the instrument build by hook `__llvm_profile_write_file()` to the `EmulationSession::ShutdownEmulation()`, so every time colse a game it will flush a profraw profile;

Run this build with some game to generate  enough profraw files;

Merge these profraw files to profdata and upload it for another job to compile the final PGO build.

But at last, the outcome seems not promising. Now only collected profdata from TOTK, didn't see noticable boost yet. 

Maybe something is still wrong or need more test for other games.